### PR TITLE
Add support for external parents in a multi-module project 

### DIFF
--- a/src/it/multi-external-parent/.gitignore
+++ b/src/it/multi-external-parent/.gitignore
@@ -1,0 +1,2 @@
+prebuild.log
+build.log

--- a/src/it/multi-external-parent/.mvn/extensions.xml
+++ b/src/it/multi-external-parent/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </extension>
+</extensions>

--- a/src/it/multi-external-parent/invoker.properties
+++ b/src/it/multi-external-parent/invoker.properties
@@ -1,0 +1,1 @@
+# invoker.mavenOpts = -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/src/it/multi-external-parent/module-1/pom.xml
+++ b/src/it/multi-external-parent/module-1/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>child</artifactId>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>fr.brouillard.oss.it.multi.with.extparents</groupId>
+        <artifactId>main</artifactId>
+        <version>0</version>
+    </parent>
+
+    <description>child::A simple IT verifying the basic use case.</description>
+</project>

--- a/src/it/multi-external-parent/module-ext-parent/pom.xml
+++ b/src/it/multi-external-parent/module-ext-parent/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>child-with-extparent</artifactId>
+    <groupId>fr.brouillard.oss.it.multi.with.extparents</groupId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.9.RELEASE</version>
+        <relativePath/>
+    </parent>
+    <description>child with ext parent:</description>
+</project>

--- a/src/it/multi-external-parent/pom.xml
+++ b/src/it/multi-external-parent/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+    
+    <groupId>fr.brouillard.oss.it.multi.with.extparents</groupId>
+    <artifactId>main</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <description>An IT verifying the use case of a multi-module project with a child module with an external parent.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-1</module>
+        <module>module-ext-parent</module>
+    </modules>
+</project>

--- a/src/it/multi-external-parent/prebuild.groovy
+++ b/src/it/multi-external-parent/prebuild.groovy
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def log = new PrintWriter( new File(basedir, "prebuild.log").newWriter("UTF-8"), true )
+log.println( "Prebuild started at: " + new Date() + " in: " + basedir )
+
+[
+        "git --version",
+        "git init",
+        "git config user.name \"nobody\"",
+        "git config user.email \"nobody@nowhere.com\"",
+        "dd if=/dev/urandom of=content bs=512 count=2",
+        "git add .",
+        "git commit --message=initial_commit",
+        "git tag -a 1.0.0 --message=release_1.0.0",
+        "dd if=/dev/urandom of=content bs=512 count=2",
+        "git add -u",
+        "git commit --message=added_B_data",
+        "git log --graph --oneline"
+
+].each{ command ->
+
+    def proc = command.execute(null, basedir)
+    def sout = new StringBuilder(), serr = new StringBuilder()
+    proc.waitForProcessOutput(sout, serr)
+
+    log.println( "cmd: " + command )
+    log.println( "out:" ) ; log.println( sout.toString().trim() )
+    log.println( "err:" ) ; log.println( serr.toString().trim() )
+    log.println( "ret: " + proc.exitValue() )
+
+    assert proc.exitValue() == 0
+
+}
+
+log.println( "Prebuild completed at: " + new Date() )
+log.close()
+return true

--- a/src/it/multi-external-parent/verify.groovy
+++ b/src/it/multi-external-parent/verify.groovy
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def baseDir = new File("$basedir")
+
+File actions = new File(baseDir, "verify-actions.log")
+actions.write 'Actions started at: ' + new Date() + '\n'
+
+actions << 'rm -rf .git'.execute(null, baseDir).text
+
+// Check the main version was used by the plugin execution
+def foundLines = new File("$basedir", "build.log").readLines().findAll { it =~ /fr.brouillard.oss.it.multi.with.extparents::main::0 -> 1.0.1-SNAPSHOT/ } 
+assert 1 == foundLines.size
+
+// Check the child version was used by the plugin execution
+foundLines = new File("$basedir", "build.log").readLines().findAll { it =~ /fr.brouillard.oss.it.multi.with.extparents::child::0 -> 1.0.1-SNAPSHOT/ } 
+assert 1 == foundLines.size
+
+// Check the child with ext parent version was used by the plugin execution
+foundLines = new File("$basedir", "build.log").readLines().findAll { it =~ /fr.brouillard.oss.it.multi.with.extparents::child-with-extparent::0 -> 1.0.1-SNAPSHOT/ } 
+assert 1 == foundLines.size
+
+// And check that the produced artifact was installed with the good version
+File installedPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/multi/with/extparents/main/1.0.1-SNAPSHOT/", "main-1.0.1-SNAPSHOT.pom")
+assert installedPomFile.isFile()
+assert 1 == installedPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+
+File installedJarPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/multi/with/extparents/child/1.0.1-SNAPSHOT/", "child-1.0.1-SNAPSHOT.pom")
+assert installedJarPomFile.isFile()
+assert 2 == installedJarPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+
+installedJarPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/multi/with/extparents/child-with-extparent/1.0.1-SNAPSHOT/", "child-with-extparent-1.0.1-SNAPSHOT.pom")
+assert installedJarPomFile.isFile()
+assert 1 == installedJarPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+assert 1 == installedJarPomFile.readLines().findAll { it =~ /<version>1.5.9.RELEASE<\/version>/ }.size()
+
+return true

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
@@ -130,10 +130,12 @@ public class JGitverModelProcessor extends DefaultModelProcessor {
 
                 if (Objects.nonNull(model.getParent())) {
                     // if the parent is part of the multi module project, let's update the parent version
+                    String modelParentRelativePath = model.getParent().getRelativePath();
                     File relativePathParent = new File(
-                            relativePath.getCanonicalPath() + File.separator + model.getParent().getRelativePath())
+                            relativePath.getCanonicalPath() + File.separator + modelParentRelativePath)
                             .getParentFile().getCanonicalFile();
-                    if (StringUtils.containsIgnoreCase(relativePathParent.getCanonicalPath(),
+                    if (StringUtils.isNotBlank(modelParentRelativePath) 
+                            && StringUtils.containsIgnoreCase(relativePathParent.getCanonicalPath(),
                             multiModuleDirectory.getCanonicalPath())) {
                         model.getParent().setVersion(calculatedVersion);
                     }


### PR DESCRIPTION
We have multi-module maven projects where some child projects have parents that are external to the project structure ( for example spring-boot parent poms: https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-build-systems.html#using-boot-maven-parent-pom ).

These are identified by the fact that the relativePath for the parent is set to be empty `<relativePath/>`

http://maven.apache.org/ref/3.0/maven-model/maven.html#parent
> Set the value to an empty string in case you want to disable the feature and always resolve the parent POM from the repositories

I have added an integration test ( `multi-external-parent` ) which fails to build under the current code and then passes with my proposed fix.  The build fails as the version number for the external parent pom is incorrectly re-written by the jgitver-maven-plugin.

Could you review this change and see if you agree?

Many thanks
David
