### PR TITLE
getting latest (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,72 @@
 # jgitver-maven-plugin changelog
 
-generated with [git-changelog-maven-plugin](https://github.com/tomasbjerre/git-changelog-maven-plugin).
+Changelog of [jgitver-maven-plugin](https://github.com/jgitver/jgitver-maven-plugin) project.
+
+## 1.0.0
+### GitHub [#44](https://github.com/jgitver/jgitver-maven-plugin/issues/44) allow to fail build when dirty
+
+**add failIfDirty configuration parameter, closes #44**
+
+
+[80f2d5d876f38cb](https://github.com/jgitver/jgitver-maven-plugin/commit/80f2d5d876f38cb) Matthieu Brouillard *2016-12-08 21:36:41*
+
+
+### GitHub [#47](https://github.com/jgitver/jgitver-maven-plugin/issues/47) cleanup old plugin code
+
+**cleanup for old plugin usage, fixes #47**
+
+
+[1f065e535a627ab](https://github.com/jgitver/jgitver-maven-plugin/commit/1f065e535a627ab) Matthieu Brouillard *2016-12-23 11:03:29*
+
+
+### GitHub [#48](https://github.com/jgitver/jgitver-maven-plugin/issues/48) Release Notes
+
+**introduce CHANGELOG.md, fix #48**
+
+
+[e4cec66c86da310](https://github.com/jgitver/jgitver-maven-plugin/commit/e4cec66c86da310) Matthieu Brouillard *2017-02-23 17:43:51*
+
+
+### GitHub [#50](https://github.com/jgitver/jgitver-maven-plugin/issues/50) Run &quot;attach-modified-poms&quot; earlier
+
+**run goal 'attach-modified-poms' as first plugin of 'prepare-package' phase**
+
+ * by default goal &#39;attach-modified-poms&#39; is now run during phase &#39;prepare-package&#39;
+ * System property &quot;jgitver.pom-replacement-phase&quot;, allows to control this default phase.
+ * For example running: mvn install -Djgitver.pom-replacement-phase=validate will execute
+ * the goal as the very first goal during a normal build flow.
+ * fix #50
+
+[60a5b787b2253a0](https://github.com/jgitver/jgitver-maven-plugin/commit/60a5b787b2253a0) Matthieu Brouillard *2017-02-20 17:05:52*
+
+
+### GitHub [#51](https://github.com/jgitver/jgitver-maven-plugin/issues/51) IDENTITY BranchNameTransformation still replaces dashes with underscores in branchname
+
+**correct loading of BranchPolicy objects when an XML schema is used**
+
+ * fix #51
+
+[3792fa3ee435152](https://github.com/jgitver/jgitver-maven-plugin/commit/3792fa3ee435152) Matthieu Brouillard *2017-02-24 11:51:34*
+
+
+### GitHub [#58](https://github.com/jgitver/jgitver-maven-plugin/issues/58) Running jgitver should be optional
+
+**introduce 'jgitver.skip' user property to skip plugin execution**
+
+ * By launching maven with &#39;-Djgitver.skip=true&#39;, you can totally skip the plugin execution.
+ * fixes #58
+
+[770992b382c3d2d](https://github.com/jgitver/jgitver-maven-plugin/commit/770992b382c3d2d) Matthieu Brouillard *2017-09-12 07:11:11*
+
+
+### GitHub [#59](https://github.com/jgitver/jgitver-maven-plugin/issues/59) Remove maven-jgit-buildnumber-plugin usage
+
+**use jgitver property 'jgitver.git_sha1_full' for git SHA1 jar manifest entry**
+
+ * fixes #59
+
+[80154c263f2d589](https://github.com/jgitver/jgitver-maven-plugin/commit/80154c263f2d589) Matthieu Brouillard *2017-09-13 05:56:00*
+
 
 ## 0.4.0
 ### GitHub [#37](https://github.com/jgitver/jgitver-maven-plugin/issues/37) It would be helpful to have .xsd for jgitver.config.xml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ __manually__
       <extension>
         <groupId>fr.brouillard.oss</groupId>
         <artifactId>jgitver-maven-plugin</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
       </extension>
     </extensions>
     ```
@@ -100,7 +100,7 @@ Please consult [jgitver](https://github.com/jgitver/jgitver#configuration-modes-
 ### Available properties
 
 Since `0.2.0`, the plugin exposes git calculated properties available during the maven build.
-Those are available under the following properties name: "jgitver.meta" where `meta` is one of [Metadatas](https://github.com/jgitver/jgitver/blob/0.2.0-alpha1/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java#L25) name in lowercase.
+Those are available under the following properties name: "jgitver.meta" where `meta` is one of [Metadatas](https://github.com/jgitver/jgitver/blob/master/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java#L25) name in lowercase.
 
 You can then use them as standard maven properties in your build:
 
@@ -245,7 +245,13 @@ build and filter some IT tests
 - `mvn -Poss,release -DskipTests deploy`
 - `git push --follow-tags origin master`
 
-## Known issues
+## Issues
+
+### I want to temporary disable the plugin execution
+
+Since `1.0.0`, it is possible to totally skip the plugin execution by launching maven with the user property `jgtiver.skip` set to `true`, example:
+
+- `mvn clean install -Djgitver.skip=true`
 
 ### maven reports my project version to be 0 (or the one set in the pom.xml)
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- dependencies versions as properties -->
-        <jgitver.version>0.3.0</jgitver.version>
+        <jgitver.version>0.4.0</jgitver.version>
         <maven-core.version>3.3.9</maven-core.version>
         <plexus-utils.version>3.0.8</plexus-utils.version>
         <maven-plugin-annotations.version>3.2</maven-plugin-annotations.version>
@@ -214,7 +214,7 @@
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                         <manifestEntries>
-                            <X-Git-CommitId>${git.revision}</X-Git-CommitId>
+                            <X-Git-CommitId>${jgitver.git_sha1_full}</X-Git-CommitId>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -251,20 +251,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>ru.concerteza.buildnumber</groupId>
-                <artifactId>maven-jgit-buildnumber-plugin</artifactId>
-                <version>1.2.9</version>
-                <executions>
-                    <execution>
-                        <id>git-buildnumber</id>
-                        <goals>
-                            <goal>extract-buildnumber</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -411,7 +397,7 @@
                     <plugin>
                         <groupId>se.bjurr.gitchangelog</groupId>
                         <artifactId>git-changelog-maven-plugin</artifactId>
-                        <version>1.39</version>
+                        <version>1.49</version>
                         <executions>
                             <execution>
                                 <id>GenerateGitChangelog</id>
@@ -422,6 +408,7 @@
                                 <configuration>
                                     <!-- A file on filesystem //-->
                                     <filePath>CHANGELOG.md</filePath>
+                                    <templateFile>src/doc/changelog.mustache</templateFile>
                                     <gitHubApi>https://api.github.com/repos/jgitver/jgitver-maven-plugin</gitHubApi>
                                     <ignoreCommitsWithoutIssue>true</ignoreCommitsWithoutIssue>
 
@@ -454,6 +441,51 @@
                                         <requireReleaseVersion />
                                     </rules>
                                     <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>properties</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <echo>version calculated: ${jgitver.calculated_version}</echo>
+                                        <echo>dirty: ${jgitver.dirty}</echo>
+                                        <echo>head_committer_name: ${jgitver.head_committer_name}</echo>
+                                        <echo>head_commiter_email: ${jgitver.head_commiter_email}</echo>
+                                        <echo>head_commit_datetime: ${jgitver.head_commit_datetime}</echo>
+                                        <echo>git_sha1_full: ${jgitver.git_sha1_full}</echo>
+                                        <echo>git_sha1_8: ${jgitver.git_sha1_8}</echo>
+                                        <echo>branch_name: ${jgitver.branch_name}</echo>
+                                        <echo>head_tags: ${jgitver.head_tags}</echo>
+                                        <echo>head_annotated_tags: ${jgitver.head_annotated_tags}</echo>
+                                        <echo>head_lightweight_tags: ${jgitver.head_lightweight_tags}</echo>
+                                        <echo>base_tag: ${jgitver.base_tag}</echo>
+                                        <echo>base_tag_type: ${jgitver.base_tag_type}</echo>
+                                        <echo>all_tags: ${jgitver.all_tags}</echo>
+                                        <echo>all_annotated_tags: ${jgitver.all_annotated_tags}</echo>
+                                        <echo>all_lightweight_tags: ${jgitver.all_lightweight_tags}</echo>
+                                        <echo>all_version_tags: ${jgitver.all_version_tags}</echo>
+                                        <echo>all_version_annotated_tags: ${jgitver.all_version_annotated_tags}</echo>
+                                        <echo>all_version_lightweight_tags: ${jgitver.all_version_lightweight_tags}</echo>
+                                        <echo>base_version: ${jgitver.base_version}</echo>
+                                        <echo>next_major_version: ${jgitver.next_major_version}</echo>
+                                        <echo>next_minor_version: ${jgitver.next_minor_version}</echo>
+                                        <echo>next_patch_version: ${jgitver.next_patch_version}</echo>
+                                    </tasks>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/doc/changelog.mustache
+++ b/src/doc/changelog.mustache
@@ -1,0 +1,32 @@
+# jgitver-maven-plugin changelog
+
+Changelog of [jgitver-maven-plugin](https://github.com/jgitver/jgitver-maven-plugin) project.
+
+{{#tags}}
+## {{name}}
+ {{#issues}}
+  {{#hasIssue}}
+   {{#hasLink}}
+### {{name}} [{{issue}}]({{link}}) {{title}}
+   {{/hasLink}}
+   {{^hasLink}}
+### {{name}} {{issue}} {{title}}
+   {{/hasLink}}
+  {{/hasIssue}}
+  {{^hasIssue}}
+### {{name}}
+  {{/hasIssue}}
+
+  {{#commits}}
+**{{{messageTitle}}}**
+
+{{#messageBodyItems}}
+ * {{.}}
+{{/messageBodyItems}}
+
+[{{hash}}](https://github.com/jgitver/jgitver-maven-plugin/commit/{{hash}}) {{authorName}} *{{commitTime}}*
+
+  {{/commits}}
+
+ {{/issues}}
+{{/tags}}

--- a/src/it/verify_skip/.mvn/extensions.xml
+++ b/src/it/verify_skip/.mvn/extensions.xml
@@ -18,8 +18,8 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
   <extension>
-    <groupId>fr.brouillard.oss</groupId>
-    <artifactId>jgitver-maven-plugin</artifactId>
-    <version>1.0.0</version>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
   </extension>
 </extensions>

--- a/src/it/verify_skip/.mvn/jgitver.config.xml
+++ b/src/it/verify_skip/.mvn/jgitver.config.xml
@@ -15,11 +15,6 @@
     limitations under the License.
 
 -->
-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-  <extension>
-    <groupId>fr.brouillard.oss</groupId>
-    <artifactId>jgitver-maven-plugin</artifactId>
-    <version>1.0.0</version>
-  </extension>
-</extensions>
+<configuration>
+    <failIfDirty>false</failIfDirty>
+</configuration>

--- a/src/it/verify_skip/invoker.properties
+++ b/src/it/verify_skip/invoker.properties
@@ -1,0 +1,2 @@
+# invoker.mavenOpts =  -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+invoker.goals = clean install -Djgitver.skip=true

--- a/src/it/verify_skip/pom.xml
+++ b/src/it/verify_skip/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
@@ -15,11 +16,17 @@
     limitations under the License.
 
 -->
-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-  <extension>
-    <groupId>fr.brouillard.oss</groupId>
-    <artifactId>jgitver-maven-plugin</artifactId>
-    <version>1.0.0</version>
-  </extension>
-</extensions>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fr.brouillard.oss.it</groupId>
+    <artifactId>skip-is-working</artifactId>
+    <version>2.0</version>
+    <packaging>pom</packaging>
+
+    <description>A simple IT verifying that extension can be skipped by property.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/src/it/verify_skip/prebuild.groovy
+++ b/src/it/verify_skip/prebuild.groovy
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def log = new PrintWriter( new File(basedir, "prebuild.log").newWriter("UTF-8"), true )
+log.println( "Prebuild started at: " + new Date() + " in: " + basedir )
+
+[
+  "git --version",
+  "rm -rf .git",
+  "git init",
+  "git config user.name nobody",
+  "git config user.email nobody@nowhere.com",
+  "echo A > content",
+  "git add .",
+  "git commit --message=initial_commit",
+  "git tag -a 1.0.0 --message=release_1.0.0",
+  "echo B > content",
+  "git add -u",
+  "git commit --message=added_b",
+  "echo C > content",
+  "git status",
+  "git log --graph --oneline"
+].each{ command ->
+
+  def proc = command.execute(null, basedir)
+  def sout = new StringBuilder(), serr = new StringBuilder()
+  proc.waitForProcessOutput(sout, serr)
+
+  log.println( "cmd: " + command )
+  log.println( "out:" ) ; log.println( sout.toString().trim() )
+  log.println( "err:" ) ; log.println( serr.toString().trim() )
+  log.println( "ret: " + proc.exitValue() )
+
+  assert proc.exitValue() == 0
+
+}
+
+log.println( "Prebuild completed at: " + new Date() )
+log.close()
+return true

--- a/src/it/verify_skip/verify.groovy
+++ b/src/it/verify_skip/verify.groovy
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def baseDir = new File("$basedir")
+
+File actions = new File(baseDir, "verify-actions.log")
+actions.write 'Actions started at: ' + new Date() + '\n'
+
+actions << 'rm -rf .git'.execute(null, baseDir).text
+
+// Check the version was used by the plugin execution
+def logLines = new File("$basedir", "build.log").readLines()
+def foundLines = logLines.findAll { it =~ /fr.brouillard.oss.it::skip-is-working::2.0 ->/ }
+assert 0 == foundLines.size
+
+foundLines = logLines.findAll { it =~ /jgitver execution has been skipped by request of the user/ }
+assert 1 == foundLines.size
+
+// And check that the produced artifact was installed with the good version
+File installedPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/skip-is-working/2.0/", "skip-is-working-2.0.pom")
+assert installedPomFile.isFile()
+assert 1 == installedPomFile.readLines().findAll { it =~ /<version>2.0<\/version>/ }.size()
+
+return true

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
@@ -147,6 +147,11 @@ public class JGitverModelProcessor extends DefaultModelProcessor {
     }
 
     private Model provisionModel(Model model, Map<String, ?> options) throws IOException {
+        if (JGitverUtils.shouldSkip(legacySupport.getSession())) {
+            // don't do anything in case of skip is active
+            return model;
+        }
+
         try {
             calculateVersionIfNecessary();
         } catch (Exception ex) {

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
@@ -51,6 +51,7 @@ public final class JGitverUtils {
     public static final String EXTENSION_PREFIX = "jgitver";
     public static final String EXTENSION_GROUP_ID = "fr.brouillard.oss";
     public static final String EXTENSION_ARTIFACT_ID = "jgitver-maven-plugin";
+    public static final String EXTENSION_SKIP = EXTENSION_PREFIX + ".skip";
 
     private JGitverUtils() {
     }
@@ -236,6 +237,11 @@ public final class JGitverUtils {
         }
     }
 
+    /**
+     * fail the build by throwing a {@link MavenExecutionException} and logging a failure message
+     * @param logger the logger to log information
+     * @throws MavenExecutionException to make the build fail
+     */
     public static void failAsOldMechanism(Consumer<? super CharSequence> logger) throws MavenExecutionException {
         logger.accept("jgitver has changed!");
         logger.accept("");
@@ -246,5 +252,19 @@ public final class JGitverUtils {
         logger.accept("");
         throw new MavenExecutionException("detection of jgitver old setting mechanism",
                 new IllegalStateException("jgitver must now use maven core extensions only"));
+    }
+
+    /**
+     * Tells if this jgitver extension should be skipped for the given maven session execution.
+     * To skip execution launch maven with a user property
+     * <pre>
+     *     mvn -Djgitver.skip=true/false
+     * </pre>
+     * The value of the property is evaluated using @{@link java.lang.Boolean#parseBoolean(String)}.
+     * @param s a running maven session
+     * @return true if jgitver extension should be skipped
+     */
+    public static boolean shouldSkip(MavenSession s) {
+        return Boolean.parseBoolean(s.getUserProperties().getProperty(EXTENSION_SKIP, "false"));
     }
 }


### PR DESCRIPTION
* update to jgitver 0.4.0

* correct link to Metadatas class from jgtiver library

* introduce 'jgitver.skip' user property to skip plugin execution

By launching maven with '-Djgitver.skip=true', you can totally skip the plugin execution.

fixes #58

* use jgitver property 'jgitver.git_sha1_full' for git SHA1 jar manifest entry

fixes #59

* fix typo in README, rephrase how to skip plugin execution

* update changelog after 1.0.0 release

* eat your own food, use jgitver-maven-plugin 1.0.0

Thank you so much to take time to contribute to the project.

Before submitting the pull-request please ensure that you have first:

- [ ] read the [contribution guidelines](https://github.com/jgitver/jgitver-maven-plugin/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased your branch over master
- [ ] verified that project is compiling and that tests pass: `mvn -Prun-its clean install`
- [ ] marked as closed (in the commit comments) all issues ID that this PR should correct