### PR TITLE
adjust detection of extension to mvn-3.6.2

### DIFF
--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverExtension.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverExtension.java
@@ -152,12 +152,7 @@ public class JGitverExtension extends AbstractMavenLifecycleParticipant {
                 if (projectBaseDir != null && !configurationProvider.ignore(new File(projectBaseDir, "pom.xml"))) {
                     final Consumer<? super CharSequence> c = cs -> logger.warn(cs.toString());
 
-                    if (JGitverModelProcessor.class.isAssignableFrom(modelProcessor.getClass())) {
-
-                        if (!mavenSession.getUserProperties().containsKey(JGitverUtils.SESSION_MAVEN_PROPERTIES_KEY)) {
-                            JGitverUtils.failAsOldMechanism(c);
-                        }
-                    } else {
+                    if (!JGitverModelProcessor.class.isAssignableFrom(modelProcessor.getClass())) {
                         JGitverUtils.failAsOldMechanism(c);
                     }
 


### PR DESCRIPTION
fixes #119 by not checking userproperties key any more. i am  not sure why it is there though with maven 3.6.2.


