### PR TITLE
add option to resolve project.version in depdencencies section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ _[Old](https://jgitver.github.io/maven/configuration/) xml schemas are kept for 
 - `-Djgitver.skip=true` : skips totally jgitver usage
 - `-Djgitver.config=FILE` : overrides default config file and uses FILE instead
 - `-Djgitver.use-version=VERSION` : execute jgitver but finally uses VERSION as the project version 
+- `-Djgitver.jgitver.resolve-project-version=true` : replaces the ${project.version} also in properties, dependencies, dependencyManagement, plugins and pluginManagement sections
 
 #### Working on a detached HEAD
 

--- a/src/it/multi-pure-extension-resolve-version-variable-it/.gitignore
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/.gitignore
@@ -1,0 +1,2 @@
+prebuild.log
+build.log

--- a/src/it/multi-pure-extension-resolve-version-variable-it/.mvn/extensions.xml
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </extension>
+</extensions>

--- a/src/it/multi-pure-extension-resolve-version-variable-it/module/pom.xml
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/module/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>multi-pure-extension-it-module</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+        <artifactId>multi-pure-extension-it</artifactId>
+        <version>0</version>
+    </parent>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+  <build>
+        <finalName>my-module-${project.version}</finalName>
+  </build>
+  
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/multi-pure-extension-resolve-version-variable-it/module/src/main/java/fr/brouillard/oss/demo/App.java
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/module/src/main/java/fr/brouillard/oss/demo/App.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.demo;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/multi-pure-extension-resolve-version-variable-it/pom.xml
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+    <artifactId>multi-pure-extension-it</artifactId>
+    <version>0</version>
+    <packaging>pom</packaging>
+
+    <description>Resolve project.version variable in properties, dependencies and plugins.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jgitver.resolve-project-version>true</jgitver.resolve-project-version>
+        <calculated-project.version>${project.version}</calculated-project.version>
+    </properties>
+
+    <modules>
+        <module>module</module>
+        <module>war</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+                <artifactId>multi-pure-extension-it-module</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+                        <artifactId>multi-pure-extension-it-module</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+                            <artifactId>multi-pure-extension-it-module</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/multi-pure-extension-resolve-version-variable-it/prebuild.groovy
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/prebuild.groovy
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def log = new PrintWriter( new File(basedir, "prebuild.log").newWriter("UTF-8"), true )
+log.println( "Prebuild started at: " + new Date() + " in: " + basedir )
+
+[
+        "git --version",
+        "git init",
+        "git config user.name \"nobody\"",
+        "git config user.email \"nobody@nowhere.com\"",
+        "dd if=/dev/urandom of=content bs=512 count=2",
+        "git add .",
+        "git commit --message=initial_commit",
+        "git tag -a 1.0.0 --message=release_1.0.0",
+        "dd if=/dev/urandom of=content bs=512 count=2",
+        "git add -u",
+        "git commit --message=added_B_data",
+        "git log --graph --oneline"
+].each{ command ->
+
+    def proc = command.execute(null, basedir)
+    def sout = new StringBuilder(), serr = new StringBuilder()
+    proc.waitForProcessOutput(sout, serr)
+
+    log.println( "cmd: " + command )
+    log.println( "out:" ) ; log.println( sout.toString().trim() )
+    log.println( "err:" ) ; log.println( serr.toString().trim() )
+    log.println( "ret: " + proc.exitValue() )
+
+    assert proc.exitValue() == 0
+}
+
+log.println( "Prebuild completed at: " + new Date() )
+log.close()
+return true

--- a/src/it/multi-pure-extension-resolve-version-variable-it/verify.groovy
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/verify.groovy
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def baseDir = new File("$basedir")
+
+File actions = new File(baseDir, "verify-actions.log")
+actions.write 'Actions started at: ' + new Date() + '\n'
+
+actions << 'rm -rf .git'.execute(null, baseDir).text
+
+// Check the version was used by the plugin execution
+def foundLines = new File("$basedir", "build.log").readLines().findAll { it =~ /fr.brouillard.oss.it.resolve-project-version::multi-pure-extension-it::0 -> 1.0.1-SNAPSHOT/ }
+assert 0 < foundLines.size
+
+// And check that the produced artifact was installed with the good version
+File installedPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/resolve-project-version/multi-pure-extension-it/1.0.1-SNAPSHOT/", "multi-pure-extension-it-1.0.1-SNAPSHOT.pom")
+assert installedPomFile.isFile()
+assert 4 == installedPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+assert 1 == installedPomFile.readLines().findAll { it =~ /<calculated-project.version>1.0.1-SNAPSHOT<\/calculated-project.version>/ }.size()
+
+File installedJarPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/resolve-project-version/multi-pure-extension-it-module/1.0.1-SNAPSHOT/", "multi-pure-extension-it-module-1.0.1-SNAPSHOT.pom")
+assert installedJarPomFile.isFile()
+assert 2 == installedJarPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+
+File installedJarFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/resolve-project-version/multi-pure-extension-it-module/1.0.1-SNAPSHOT/", "multi-pure-extension-it-module-1.0.1-SNAPSHOT.jar")
+assert installedJarFile.isFile()
+
+File installedWarPomFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/resolve-project-version/multi-pure-extension-it-app/1.0.1-SNAPSHOT/", "multi-pure-extension-it-app-1.0.1-SNAPSHOT.pom")
+assert installedWarPomFile.isFile()
+assert 3 == installedWarPomFile.readLines().findAll { it =~ /<version>1.0.1-SNAPSHOT<\/version>/ }.size()
+
+File installedWarFile = new File("$basedir" + "/../../local-repo/fr/brouillard/oss/it/resolve-project-version/multi-pure-extension-it-app/1.0.1-SNAPSHOT/", "multi-pure-extension-it-app-1.0.1-SNAPSHOT.war")
+assert installedWarFile.isFile()
+return true

--- a/src/it/multi-pure-extension-resolve-version-variable-it/war/pom.xml
+++ b/src/it/multi-pure-extension-resolve-version-variable-it/war/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>multi-pure-extension-it-app</artifactId>
+    <packaging>war</packaging>
+
+    <parent>
+        <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+        <artifactId>multi-pure-extension-it</artifactId>
+        <version>0</version>
+    </parent>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <finalName>webapp</finalName>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.brouillard.oss.it.resolve-project-version</groupId>
+            <artifactId>multi-pure-extension-it-module</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
@@ -15,6 +15,19 @@
  */
 package fr.brouillard.oss.jgitver;
 
+import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -23,22 +36,11 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.MavenExecutionException;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
-import fr.brouillard.oss.jgitver.metadata.Metadatas;
 
 /**
  * Misc utils used by the plugin.
@@ -51,6 +53,7 @@ public final class JGitverUtils {
     public static final String EXTENSION_FLATTEN = EXTENSION_PREFIX + ".flatten";
     public static final String EXTENSION_USE_VERSION = EXTENSION_PREFIX + ".use-version";
     public static final String SESSION_MAVEN_PROPERTIES_KEY = EXTENSION_PREFIX + ".session";
+    public static final String PROJECT_VERSION = "${project.version}";
 
     public interface CLI {
         String OVERRIDE_CONFIG_FILE = EXTENSION_PREFIX + ".config";
@@ -101,9 +104,9 @@ public final class JGitverUtils {
     /**
      * Changes basedir(dangerous).
      *
-     * @param project project.
+     * @param project        project.
      * @param initialBaseDir initialBaseDir.
-     * @throws NoSuchFieldException NoSuchFieldException.
+     * @throws NoSuchFieldException   NoSuchFieldException.
      * @throws IllegalAccessException IllegalAccessException.
      */
     // It breaks the build process, because it changes the basedir to 'tmp'/... where other plugins are not able to
@@ -117,9 +120,10 @@ public final class JGitverUtils {
 
     /**
      * Changes the pom file of the given project.
+     *
      * @param project the project to change the pom
-     * @param newPom the pom file to set on the project
-     * @param logger a logger to use 
+     * @param newPom  the pom file to set on the project
+     * @param logger  a logger to use
      */
     public static void setProjectPomFile(MavenProject project, File newPom, Logger logger) {
         try {
@@ -143,9 +147,9 @@ public final class JGitverUtils {
     /**
      * Fill properties from meta data.
      *
-     * @param properties     properties.
+     * @param properties          properties.
      * @param informationProvider the jgitver to extract information from.
-     * @param logger         logger.
+     * @param logger              logger.
      */
     public static void fillPropertiesFromMetadatas(Properties properties, JGitverInformationProvider informationProvider, Logger logger) {
         String calculatedVersion = informationProvider.getVersion();
@@ -166,15 +170,15 @@ public final class JGitverUtils {
     /**
      * Attach modified POM files to the projects so install/deployed files contains new version.
      *
-     * @param projects           projects.
-     * @param gavs list of registered GAVs of modified projects.
-     * @param version the version to set
-     * @param logger the logger to report to
-     * @throws IOException if project model cannot be read correctly
+     * @param projects projects.
+     * @param gavs     list of registered GAVs of modified projects.
+     * @param version  the version to set
+     * @param logger   the logger to report to
+     * @throws IOException            if project model cannot be read correctly
      * @throws XmlPullParserException if project model cannot be interpreted correctly
      */
     public static void attachModifiedPomFilesToTheProject(List<MavenProject> projects, Set<GAV>
-            gavs, String version, Logger logger) throws IOException, XmlPullParserException {
+            gavs, String version, Boolean resolveProjectVersion, Logger logger) throws IOException, XmlPullParserException {
         for (MavenProject project : projects) {
             Model model = loadInitialModel(project.getFile());
             GAV initalProjectGAV = GAV.from(model);     // SUPPRESS CHECKSTYLE AbbreviationAsWordInName
@@ -198,6 +202,10 @@ public final class JGitverUtils {
                 }
             }
 
+            if(resolveProjectVersion) {
+                resolveProjectVersionVariable(version, model);
+            }
+
             File newPom = createPomDumpFile();
             writeModelPom(model, newPom);
             logger.debug("    new pom file created for " + initalProjectGAV + " under " + newPom);
@@ -207,12 +215,69 @@ public final class JGitverUtils {
         }
     }
 
+    private static void resolveProjectVersionVariable(String version, Model model) {
+        // resolve project.version in properties
+        if (model.getProperties() != null) {
+            for (Map.Entry<Object, Object> entry : model.getProperties().entrySet()) {
+                if (PROJECT_VERSION.equals(entry.getValue())) {
+                    entry.setValue(version);
+                }
+            }
+        }
+
+        // resolve project.version in dependencies
+        if (model.getDependencies() != null) {
+            for (Dependency dependency : model.getDependencies()) {
+                if (PROJECT_VERSION.equals(dependency.getVersion())) {
+                    dependency.setVersion(version);
+                }
+            }
+        }
+
+        // resole project.version in dependencyManagement
+        if (model.getDependencyManagement() != null && model.getDependencyManagement().getDependencies() != null) {
+            for (Dependency dependency : model.getDependencyManagement().getDependencies()) {
+                if (PROJECT_VERSION.equals(dependency.getVersion())) {
+                    dependency.setVersion(version);
+                }
+            }
+        }
+
+        // resolve project.version in plugins
+        if (model.getBuild() != null && model.getBuild().getPlugins() != null) {
+            for (Plugin plugin : model.getBuild().getPlugins()) {
+                if (plugin.getDependencies() != null) {
+                    for (Dependency dependency : plugin.getDependencies()) {
+                        if (PROJECT_VERSION.equals(dependency.getVersion())) {
+                            dependency.setVersion(version);
+                        }
+                    }
+                }
+            }
+        }
+
+        // resolve project.version in pluginManagement
+        if (model.getBuild() != null && model.getBuild().getPluginManagement() != null && model.getBuild().getPluginManagement().getPlugins() != null) {
+            for (Plugin plugin : model.getBuild().getPluginManagement().getPlugins()) {
+                if (plugin.getDependencies() != null) {
+                    for (Dependency dependency : plugin.getDependencies()) {
+                        if (PROJECT_VERSION.equals(dependency.getVersion())) {
+                            dependency.setVersion(version);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * fail the build by throwing a {@link MavenExecutionException} and logging a failure message.
+     *
      * @param logger the logger to log information
      * @throws MavenExecutionException to make the build fail
      */
-    public static void failAsOldMechanism(Consumer<? super CharSequence> logger) throws MavenExecutionException {
+    public static void failAsOldMechanism(Consumer<? super CharSequence> logger) throws
+            MavenExecutionException {
         logger.accept("jgitver has changed!");
         logger.accept("");
         logger.accept("it now requires the usage of maven core extensions (> 3.3.1) instead of standard plugin extensions.");
@@ -231,6 +296,7 @@ public final class JGitverUtils {
      *     mvn -Djgitver.skip=true/false
      * </pre>
      * The value of the property is evaluated using @{@link java.lang.Boolean#parseBoolean(String)}.
+     *
      * @param session a running maven session
      * @return true if jgitver extension should be skipped
      */
@@ -245,6 +311,7 @@ public final class JGitverUtils {
      *     mvn -Djgitver.flatten=true/false
      * </pre>
      * The value of the property is evaluated using @{@link java.lang.Boolean#parseBoolean(String)}.
+     *
      * @param session a running maven session
      * @return true if jgitver extension should use flatten
      */
@@ -254,8 +321,9 @@ public final class JGitverUtils {
 
     /**
      * Provides the version to use if defined as user or system property.
+     *
      * @param session a running maven session
-     * @param logger logger
+     * @param logger  logger
      * @return an Optional containing the version to use if the corresponding user or system property has been defined
      */
     public static Optional<String> versionOverride(final MavenSession session, final Logger logger) {
@@ -272,12 +340,13 @@ public final class JGitverUtils {
      * <p>User properties have higher priority than all other properties. Environment properties have higher priority
      * than system properties. Exact matches have higher priority than IEEE Std 1003.1-2001 compliant versions.
      *
-     * @param session A running maven session.
+     * @param session      A running maven session.
      * @param propertyName The name of the property to retrieve.
-     * @param logger logger.
+     * @param logger       logger.
      * @return The value of the property of empty if it has not been defined.
      */
-    public static Optional<String> getProperty(final MavenSession session, final String propertyName, final Logger logger) {
+    public static Optional<String> getProperty(final MavenSession session, final String propertyName,
+                                               final Logger logger) {
         final String normalizedSystemPropertyName = normalizeSystemPropertyName(propertyName);
 
         String value;

--- a/src/main/java/fr/brouillard/oss/jgitver/mojos/JGitverAttachModifiedPomsMojo.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/mojos/JGitverAttachModifiedPomsMojo.java
@@ -38,6 +38,9 @@ public class JGitverAttachModifiedPomsMojo extends AbstractMojo {
     @Parameter(defaultValue = "${session}", readonly = true)
     private MavenSession mavenSession;
 
+    @Parameter(property = "jgitver.resolve-project-version", defaultValue = "false")
+    private Boolean resolveProjectVersion;
+
     @Override
     public void execute() throws MojoExecutionException {
         if (Objects.isNull(mavenSession.getUserProperties().get(JGitverUtils.SESSION_MAVEN_PROPERTIES_KEY))) {
@@ -54,9 +57,12 @@ public class JGitverAttachModifiedPomsMojo extends AbstractMojo {
 
         try {
             JGitverSession jgitverSession = JGitverSession.serializeFrom(content);
-            JGitverUtils.attachModifiedPomFilesToTheProject(mavenSession.getAllProjects(),
-                    jgitverSession.getProjects(), jgitverSession.getVersion(), new
-                            ConsoleLogger());
+            JGitverUtils.attachModifiedPomFilesToTheProject(
+                    mavenSession.getAllProjects(),
+                    jgitverSession.getProjects(),
+                    jgitverSession.getVersion(),
+                    resolveProjectVersion,
+                    new ConsoleLogger());
             mavenSession.getUserProperties().setProperty(JGitverUtils.SESSION_MAVEN_PROPERTIES_KEY, "-");
         } catch (Exception ex) {
             throw new MojoExecutionException("Unable to execute goal: "


### PR DESCRIPTION
This closes #129 - the `maven-flatten-plugin` is not a practical alternative to replace the ${project.version} variables in the pom.xml, as there is no option to just simply replace this specific variable.

Thank you so much to take time to contribute to the project.

Before submitting the pull-request please ensure that you have first:

- [x] read the [contribution guidelines](https://github.com/jgitver/jgitver-maven-plugin/blob/master/.github/CONTRIBUTING.md)
- [x] rebased your branch over master
- [x] verified that project is compiling and that tests pass: `mvn -Prun-its clean install`
- [x] marked as closed (in the commit comments) all issues ID that this PR should correct