### PR TITLE
Add Guice module to bind JGitverConfiguration to JGitverConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.2.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>

--- a/src/main/java/fr/brouillard/oss/jgitver/JgitverGuiceModule.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JgitverGuiceModule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.brouillard.oss.jgitver;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * Guice binding for {@link fr.brouillard.oss.jgitver.JGitverConfiguration}.
+ *
+ * <p>Without a guice binding looking up the ProjectBuilder on other plugins will throw an exception trying to
+ * load {@link fr.brouillard.oss.jgitver.JGitverConfiguration} (only started on maven 3.6.3).
+ */
+public class JgitverGuiceModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(JGitverConfiguration.class).to(JGitverConfigurationComponent.class);
+    }
+}


### PR DESCRIPTION
Without a Guice binding looking up the org.apache.maven.project.ProjectBuilder on other plugins will throw an exception trying to load {@link fr.brouillard.oss.jgitver.JGitverConfiguration} (only started on maven 3.6.3).
```
1) No implementation for fr.brouillard.oss.jgitver.JGitverConfiguration was bound.
  while locating fr.brouillard.oss.jgitver.JGitverModelProcessor
  at ClassRealm[plugin>fr.brouillard.oss:jgitver-maven-plugin:1.5.1, parent: sun.misc.Launcher$AppClassLoader@5c647e05] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
  while locating org.apache.maven.model.building.ModelProcessor
  at org.eclipse.sisu.wire.LocatorWiring
  while locating org.apache.maven.model.building.ModelProcessor
    for field at org.apache.maven.model.building.DefaultModelBuilder.modelProcessor(Unknown Source)
  while locating com.feedzai.commons.maven.license.builder.ScopeFilterModelBuilder
```