### PR TITLE
make javadoc work with java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <maven-invoker-plugin.version>1.10</maven-invoker-plugin.version>
-        <spotless.version>2.6.1</spotless.version>
+        <spotless.version>2.8.1</spotless.version>
     </properties>
 
     <developers>
@@ -458,7 +458,7 @@
                     <configuration>
                         <java>
                             <googleJavaFormat>
-                                <version>1.9</version>
+                                <version>1.7</version>
                                 <style>GOOGLE</style>
                             </googleJavaFormat>
                         </java>
@@ -713,7 +713,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.2.0</version>
                         <configuration>
                             <source>1.8</source>
                         </configuration>

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
@@ -48,8 +48,6 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-;
-
 /** Replacement ModelProcessor using jgitver while loading POMs in order to adapt versions. */
 @Component(role = ModelProcessor.class)
 public class JGitverModelProcessor extends DefaultModelProcessor {


### PR DESCRIPTION
currently ther  are two problems. first is with diffplus spotless,
which fails the formatting when using java8:
https://github.com/diffplug/spotless/issues/658

second, javadoc fails when using java9 and newer when not setting
JAVA_HOME like on many linux distros, and macos:
https://github.com/apache/maven-javadoc-plugin/commit/4bf64b02

this will be only fixed with the maven-javadoc-plugin- 3.2.1
whenever it will be released.

Thank you so much to take time to contribute to the project.

Before submitting the pull-request please ensure that you have first:

- [ ] read the [contribution guidelines](https://github.com/jgitver/jgitver-maven-plugin/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased your branch over master
- [ ] verified that project is compiling and that tests pass: `mvn -Prun-its clean install`
- [ ] marked as closed (in the commit comments) all issues ID that this PR should correct