### PR TITLE
Support for export of info properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ _[Old](https://jgitver.github.io/maven/configuration/) xml schemas are kept for 
 - `-Djgitver.config=FILE` : overrides default config file and uses FILE instead
 - `-Djgitver.use-version=VERSION` : execute jgitver but finally uses VERSION as the project version 
 - `-Djgitver.resolve-project-version=true` : replaces the ${project.version} also in properties, dependencies, dependencyManagement, plugins and pluginManagement sections
+- `-Djgitver.export-properties-path=FILE` : exports output properties into the given file
 
 #### Working on a detached HEAD
 
@@ -119,13 +120,16 @@ Since `1.3.0` it now possible to provide externally the _branch_ information via
 - `JGITVER_BRANCH=SOME_BRANCH_NAME && mvn validate` for bash like shells
 - `SET JGITVER_BRANCH=SOME_BRANCH_NAME`  
     `mvn validate`  
-    for windows CMD (I don't know a one iner solution)
+    for windows CMD (I don't know a one liner solution)
 
 
-### Available properties
+### Available output properties
 
-Since `0.2.0`, the plugin exposes git calculated properties available during the maven build.
-Those are available under the following properties name: "jgitver.meta" where `meta` is one of [Metadatas](https://github.com/jgitver/jgitver/blob/master/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java#L25) name in lowercase.
+The plugin exposes git calculated properties available during the maven build.
+Those are available under the following properties name: "jgitver.meta" where `meta` is one 
+of [Metadatas](https://github.com/jgitver/jgitver/blob/master/src/main/java/fr/brouillard/oss/jgitver/metadata/Metadatas.java#L25) name in lowercase
+in addition to `jgitver.used_version` which represents the version ultimately
+applied (in case it was overriden on the command line using `-Djgitver.use-version=VERSION`).
 
 You can then use them as standard maven properties in your build:
 
@@ -191,6 +195,18 @@ resulted in my case
      [echo] all_version_lightweight_tags: v0.2.0
 [INFO] Executed tasks
 ```
+
+You can also output the properties into a file so that they can be picked
+up by the next steps in your build pipeline. This is accomplished by setting
+the `jgitver.export-properties-path` system property, e.g. from the command
+line:
+
+``` text
+    mvn ... -Djgitver.export-properties-path=./jgitver-output.properties
+```
+
+The produced file follows the [Java Properties standard](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).   
+
 
 ## Example
 

--- a/src/it/verify-export-properties/.gitignore
+++ b/src/it/verify-export-properties/.gitignore
@@ -1,0 +1,2 @@
+prebuild.log
+build.log

--- a/src/it/verify-export-properties/.mvn/extensions.xml
+++ b/src/it/verify-export-properties/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </extension>
+</extensions>

--- a/src/it/verify-export-properties/.mvn/jgitver.config.xml
+++ b/src/it/verify-export-properties/.mvn/jgitver.config.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <failIfDirty>false</failIfDirty>
+</configuration>

--- a/src/it/verify-export-properties/invoker.properties
+++ b/src/it/verify-export-properties/invoker.properties
@@ -1,0 +1,2 @@
+# invoker.mavenOpts =  -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+invoker.goals = clean verify -Djgitver.export-properties-path=./jgitver-output.properties

--- a/src/it/verify-export-properties/pom.xml
+++ b/src/it/verify-export-properties/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fr.brouillard.oss.it</groupId>
+    <artifactId>export-properties-is-working</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>A simple IT verifying that properties are exported into a file if so requested</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/src/it/verify-export-properties/prebuild.groovy
+++ b/src/it/verify-export-properties/prebuild.groovy
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def log = new PrintWriter( new File(basedir, "prebuild.log").newWriter("UTF-8"), true )
+log.println( "Prebuild started at: " + new Date() + " in: " + basedir )
+
+[
+  "git --version",
+  "rm -rf .git",
+  "git init",
+  "git config user.name nobody",
+  "git config user.email nobody@nowhere.com",
+  "dd if=/dev/urandom of=content bs=512 count=2",
+  "git add .",
+  "git commit --message=initial_commit",
+  "git tag -a 1.0.0 --message=release_1.0.0",
+  "dd if=/dev/urandom of=content bs=512 count=2",
+  "git add -u",
+  "git commit --message=added_b",
+  "dd if=/dev/urandom of=content bs=512 count=2",
+  "git status",
+  "git log --graph --oneline"
+].each{ command ->
+
+  def proc = command.execute(null, basedir)
+  def sout = new StringBuilder(), serr = new StringBuilder()
+  proc.waitForProcessOutput(sout, serr)
+
+  log.println( "cmd: " + command )
+  log.println( "out:" ) ; log.println( sout.toString().trim() )
+  log.println( "err:" ) ; log.println( serr.toString().trim() )
+  log.println( "ret: " + proc.exitValue() )
+
+  assert proc.exitValue() == 0
+
+}
+
+log.println( "Prebuild completed at: " + new Date() )
+log.close()
+return true

--- a/src/it/verify-export-properties/verify.groovy
+++ b/src/it/verify-export-properties/verify.groovy
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 Matthieu Brouillard [http://oss.brouillard.fr/jgitver-maven-plugin] (matthieu@brouillard.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def baseDir = new File("$basedir")
+def exportedPropsFileStr = 'jgitver-output.properties'
+
+File actions = new File(baseDir, "verify-actions.log")
+actions.write 'Actions started at: ' + new Date() + '\n'
+
+actions << 'rm -rf .git'.execute(null, baseDir).text
+
+def logLines = new File("$basedir", "build.log").readLines()
+foundLines = logLines.findAll { it =~ /Properties exported to/ }
+assert 1 == foundLines.size
+
+File exportedPropsFile = new File(basedir, exportedPropsFileStr)
+assert exportedPropsFile.isFile()
+
+Properties properties = new Properties()
+exportedPropsFile.withInputStream {
+    properties.load(it)
+}
+
+// The should be a decent amount of properties 
+assert properties.size() >= 10
+
+
+
+
+return true

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverUtils.java
@@ -46,12 +46,16 @@ public final class JGitverUtils {
   public static final String EXTENSION_PREFIX = "jgitver";
   public static final String EXTENSION_GROUP_ID = "fr.brouillard.oss";
   public static final String EXTENSION_ARTIFACT_ID = "jgitver-maven-plugin";
+  public static final String SESSION_MAVEN_PROPERTIES_KEY = EXTENSION_PREFIX + ".session";
+  public static final String PROJECT_VERSION = "${project.version}";
+
+  // Command line keys
   public static final String EXTENSION_SKIP = EXTENSION_PREFIX + ".skip";
   public static final String EXTENSION_FORCE_COMPUTATION = EXTENSION_PREFIX + ".forceComputation";
   public static final String EXTENSION_FLATTEN = EXTENSION_PREFIX + ".flatten";
   public static final String EXTENSION_USE_VERSION = EXTENSION_PREFIX + ".use-version";
-  public static final String SESSION_MAVEN_PROPERTIES_KEY = EXTENSION_PREFIX + ".session";
-  public static final String PROJECT_VERSION = "${project.version}";
+  public static final String EXTENSION_EXPORT_PROPERTIES_PATH =
+      EXTENSION_PREFIX + ".export-properties-path";
 
   public interface CLI {
     String OVERRIDE_CONFIG_FILE = EXTENSION_PREFIX + ".config";
@@ -369,6 +373,19 @@ public final class JGitverUtils {
    */
   public static Optional<String> versionOverride(final MavenSession session, final Logger logger) {
     return getProperty(session, EXTENSION_USE_VERSION, logger);
+  }
+
+  /**
+   * Provides the path (file name) to export properties to if defined as user or system property.
+   *
+   * @param session a running maven session
+   * @param logger logger
+   * @return an Optional containing the output filename to use if the corresponding user or system
+   *     property has been defined
+   */
+  public static Optional<String> exportPropertiesPath(
+      final MavenSession session, final Logger logger) {
+    return getProperty(session, EXTENSION_EXPORT_PROPERTIES_PATH, logger);
   }
 
   /**


### PR DESCRIPTION
New feature: 
If `jgitver.export-properties-path=FILE` is defined as a System Property, for example on the command line:

```text
mvn ... -Djgitver.export-properties-path=./jgitver-output.properties
```
then a properties file, `FILE`, will be generated with the jgitver info properties.

This enables such properties to be picked up by the remainder of the CI pipeline.

Design choices:
- I've opted for a System Property to control this rather than an element in config file. The reason is that for the moment - for existing config options - the distinction seems to be that config file configures `jigitver` (the library) while System Properties configure the maven extension. I wanted to be compliant with that tradition.
- If the file cannot be written it is considered a breaking error for the Maven execution. The rationale is: If user has specified this sysprop he surely has an expectation that it will be created.

Furthermore this PR 

- ads Integration test case (`verify-export-properties`)
- Amends README in order to document the new feature (and adds documentation about what the `jgitver.used_version` property means although not related directly to this PR)




Fixes #163
