### PR TITLE
Show latest published version: Added Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # jgitver-maven-plugin
 
-[![Sponsor](https://img.shields.io/badge/sponsor-jgitver-blue?logo=github-sponsors)](https://github.com/sponsors/McFoggy) [![Build Status](https://travis-ci.org/jgitver/jgitver-maven-plugin.svg?branch=master)](https://travis-ci.org/jgitver/jgitver-maven-plugin)
-[![Open Hub project report for jgitver-maven-plugin](https://www.openhub.net/p/jgitver-maven-plugin/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jgitver-maven-plugin?ref=sample) [![Discuss](https://badges.gitter.im/jgitver/jgitver.svg)](https://gitter.im/jgitver/Lobby)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/fr.brouillard.oss/jgitver-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/fr.brouillard.oss/jgitver-maven-plugin)
+[![Sponsor](https://img.shields.io/badge/sponsor-jgitver-blue?logo=github-sponsors)](https://github.com/sponsors/McFoggy)
+[![Build Status](https://travis-ci.org/jgitver/jgitver-maven-plugin.svg?branch=master)](https://travis-ci.org/jgitver/jgitver-maven-plugin)
+[![Open Hub project report for jgitver-maven-plugin](https://www.openhub.net/p/jgitver-maven-plugin/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jgitver-maven-plugin?ref=sample)
+[![Discuss](https://badges.gitter.im/jgitver/jgitver.svg)](https://gitter.im/jgitver/Lobby)
 
 This plugin allows to define the pom version of your project using the information from your git history.
 It calculates the version, a little bit like `git describe` would do but in a more efficient way for maven projects:


### PR DESCRIPTION
The badge shows what the latest published version is.

Also added some line-breaks in the "badges" section for readability of the Markdown.
(badges are still rendered on a single line)
