### PR TITLE
Fixed url in install.sh script

### DIFF
--- a/src/doc/scripts/install.sh
+++ b/src/doc/scripts/install.sh
@@ -15,11 +15,13 @@
 # limitations under the License.
 #
 
+SEARCH_MAVEN_URL="https://search.maven.org/solrsearch/select?q=g:%22fr.brouillard.oss%22+AND+a:%22jgitver-maven-plugin%22&core=gav&rows=1&wt=json"
+
 if command -v jq >/dev/null; then
-    JGITVER_LATEST_VERSION=`curl -s "http://search.maven.org/solrsearch/select?q=g:%22fr.brouillard.oss%22+AND+a:%22jgitver-maven-plugin%22&core=gav&rows=1&wt=json" | jq '.response.docs[0].v' | tr -d '"'`
+    JGITVER_LATEST_VERSION=`curl -s "$SEARCH_MAVEN_URL" | jq '.response.docs[0].v' | tr -d '"'`
 else 
     if command -v python >/dev/null; then
-        JGITVER_LATEST_VERSION=`curl -s "http://search.maven.org/solrsearch/select?q=g:%22fr.brouillard.oss%22+AND+a:%22jgitver-maven-plugin%22&core=gav&rows=1&wt=json" | python -mjson.tool \
+        JGITVER_LATEST_VERSION=`curl -s "$SEARCH_MAVEN_URL" | python -mjson.tool \
             | grep '"v"' | tr -d '", ' | cut -d ':' -f 2`
     else
         echo missing jq or python, cannot create automatically jgitver maven extension file.


### PR DESCRIPTION
Old url (http://) returned http page with 301 status:

      <html>
      <head><title>301 Moved Permanently</title></head>
      <body>
      <center><h1>301 Moved Permanently</h1></center>
      <hr><center>nginx</center>
      </body>
      </html>

Url ws changed to https://.

Thank you so much to take time to contribute to the project.

Before submitting the pull-request please ensure that you have first:

- [ ] read the [contribution guidelines](https://github.com/jgitver/jgitver-maven-plugin/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased your branch over master
- [ ] verified that project is compiling and that tests pass: `mvn -Prun-its clean install`
- [ ] marked as closed (in the commit comments) all issues ID that this PR should correct