### PR TITLE
Transition plexus annotations to JSR-330

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <maven-core.version>3.3.9</maven-core.version>
         <plexus-utils.version>3.1.0</plexus-utils.version>
         <maven-plugin-annotations.version>3.2</maven-plugin-annotations.version>
-        <plexus-component-annotations.version>1.5.5</plexus-component-annotations.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <guava.version>27.0.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
@@ -137,6 +136,11 @@
             <version>2.2.11</version>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven-core.version}</version>
@@ -158,12 +162,6 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven-core.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-annotations</artifactId>
-            <version>${plexus-component-annotations.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -264,6 +262,20 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>0.3.5</version>
+                <executions>
+                    <execution>
+                        <id>index-project</id>
+                        <goals>
+                            <goal>main-index</goal>
+                            <goal>test-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverConfigurationComponent.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverConfigurationComponent.java
@@ -21,19 +21,21 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 
-@Component(role = JGitverConfiguration.class, instantiationStrategy = "singleton")
+@Named
+@Singleton
 public class JGitverConfigurationComponent implements JGitverConfiguration {
-  @Requirement private LegacySupport legacySupport = null;
+  @Inject private LegacySupport legacySupport = null;
 
-  @Requirement private Logger logger = null;
+  @Inject private Logger logger = null;
 
   private volatile Configuration configuration;
 

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverExtension.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverExtension.java
@@ -17,6 +17,16 @@ package fr.brouillard.oss.jgitver;
 
 import fr.brouillard.oss.jgitver.cfg.Configuration;
 import fr.brouillard.oss.jgitver.metadata.Metadatas;
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.building.ModelProcessor;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.logging.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -26,26 +36,19 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.apache.maven.AbstractMavenLifecycleParticipant;
-import org.apache.maven.MavenExecutionException;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.building.ModelProcessor;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.Logger;
 
-@Component(role = AbstractMavenLifecycleParticipant.class, hint = "jgitver")
+@Named("jgitver")
+@Singleton
 public class JGitverExtension extends AbstractMavenLifecycleParticipant {
-  @Requirement private Logger logger;
+  @Inject private Logger logger;
 
-  @Requirement private PlexusContainer container;
+  @Inject private PlexusContainer container;
 
-  @Requirement private ModelProcessor modelProcessor;
+  @Inject private ModelProcessor modelProcessor;
 
-  @Requirement private JGitverSessionHolder sessionHolder;
+  @Inject private JGitverSessionHolder sessionHolder;
 
-  @Requirement private JGitverConfiguration configurationProvider;
+  @Inject private JGitverConfiguration configurationProvider;
 
   @Override
   public void afterSessionStart(MavenSession mavenSession) throws MavenExecutionException {

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverModelProcessor.java
@@ -30,6 +30,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Predicate;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.building.Source;
@@ -43,25 +46,24 @@ import org.apache.maven.model.Scm;
 import org.apache.maven.model.building.DefaultModelProcessor;
 import org.apache.maven.model.building.ModelProcessor;
 import org.apache.maven.plugin.LegacySupport;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 ;
 
 /** Replacement ModelProcessor using jgitver while loading POMs in order to adapt versions. */
-@Component(role = ModelProcessor.class)
+@Singleton
+@Named
 public class JGitverModelProcessor extends DefaultModelProcessor {
   public static final String FLATTEN_MAVEN_PLUGIN = "flatten-maven-plugin";
   public static final String ORG_CODEHAUS_MOJO = "org.codehaus.mojo";
-  @Requirement private Logger logger = null;
+  @Inject private Logger logger = null;
 
-  @Requirement private LegacySupport legacySupport = null;
+  @Inject private LegacySupport legacySupport = null;
 
-  @Requirement private JGitverConfiguration configurationProvider;
+  @Inject private JGitverConfiguration configurationProvider;
 
-  @Requirement private JGitverSessionHolder jgitverSession;
+  @Inject private JGitverSessionHolder jgitverSession;
 
   public JGitverModelProcessor() {
     super();

--- a/src/main/java/fr/brouillard/oss/jgitver/JGitverSessionHolder.java
+++ b/src/main/java/fr/brouillard/oss/jgitver/JGitverSessionHolder.java
@@ -16,9 +16,11 @@
 package fr.brouillard.oss.jgitver;
 
 import java.util.Optional;
-import org.codehaus.plexus.component.annotations.Component;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
-@Component(role = JGitverSessionHolder.class, instantiationStrategy = "singleton")
+@Named
+@Singleton
 public class JGitverSessionHolder {
   private JGitverSession session = null;
 


### PR DESCRIPTION
This change transitions the project to JSR-330 annotations by following this [guide](https://maven.apache.org/maven-jsr330.html) and [this](https://github.com/eclipse/sisu.plexus/wiki/Plexus-to-JSR330).

This doesn't touch any tests as we're not expecting any impacts.